### PR TITLE
Add CLI options for custom file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ pip install -r requirements.txt
 1. Заполните файл `input.txt` строками для проверки.
 2. Запустите скрипт:
    ```bash
-   python main.py
+   python main.py [--db DB_PATH] [--output OUTPUT_PATH] [--input INPUT_PATH]
    ```
-   или на Windows можно использовать `Start_NoClone.bat`.
+   Параметры необязательны. По умолчанию используются файлы `IdsBD.txt`,
+   `GoodId.txt` и `input.txt`. На Windows можно использовать `Start_NoClone.bat`.
 3. Результаты:
    - `IdsBD.txt` – накопительная база уникальных строк;
    - `GoodId.txt` – новые уникальные строки текущего запуска;


### PR DESCRIPTION
## Summary
- integrate `argparse` into `main.py`
- allow configuring database, output, and input file paths via CLI
- update README usage section for new options

## Testing
- `python -m py_compile main.py`
- `python main.py --help`
- `printf 'a\na\n\nb\n' > input.txt && python main.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1635cf71083258f6e4882a0156317